### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ fabric-scripts
 [![Docs Status](https://readthedocs.org/projects/fabric-scripts/badge/?version=latest)](http://fabric-scripts.readthedocs.org/en/latest/index.html)
 [![Coverage Status](https://coveralls.io/repos/paulocheque/fabric-scripts/badge.png?branch=master)](https://coveralls.io/r/paulocheque/fabric-scripts?branch=master)
 [![Code Status](https://landscape.io/github/paulocheque/fabric-scripts/master/landscape.png)](https://landscape.io/github/paulocheque/fabric-scripts/)
-[![PyPi version](https://pypip.in/v/fabric-scripts/badge.png)](https://crate.io/packages/fabric-scripts/)
-[![PyPi downloads](https://pypip.in/d/fabric-scripts/badge.png)](https://crate.io/packages/fabric-scripts/)
+[![PyPi version](https://img.shields.io/pypi/v/fabric-scripts.svg)](https://crate.io/packages/fabric-scripts/)
+[![PyPi downloads](https://img.shields.io/pypi/dm/fabric-scripts.svg)](https://crate.io/packages/fabric-scripts/)
 
 **Latest version: 0.0.26 (2015/10)**
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20fabric-scripts))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `fabric-scripts`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.